### PR TITLE
Add support for multichain governors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .git
 build
+.DS_Store

--- a/src/components/appeal-module.js
+++ b/src/components/appeal-module.js
@@ -37,6 +37,7 @@ const AppealSubtext = styled.div`
 
 export default ({
   governorContractInstance,
+  chain,
   arbitratorContractInstance,
   session,
   web3,
@@ -130,6 +131,7 @@ export default ({
                     }
                     rewardPercentage={i === currentRuling - 1 ? "100" : "50"}
                     governorContractInstance={governorContractInstance}
+                    chain={chain}
                     submissionIndex={i}
                     account={account}
                   />

--- a/src/components/appeal/appeal-side-box.js
+++ b/src/components/appeal/appeal-side-box.js
@@ -57,6 +57,7 @@ export default ({
   amountContributed,
   rewardPercentage,
   governorContractInstance,
+  chain,
   account,
 }) => {
   const amountRemaining = Web3.utils.fromWei(
@@ -74,7 +75,7 @@ export default ({
       <Row>
         <Col lg={3}>
           <Identicon
-            href={`https://etherscan.io/address/${submitter}`}
+            href={chain.scanAddressUrl(submitter)}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/appeal/appeal-side-box.js
+++ b/src/components/appeal/appeal-side-box.js
@@ -7,6 +7,7 @@ import TimeAgo from "../time-ago";
 import { shortenEthAddress } from "../../util/text";
 import BlueBanner from "../blue-banner";
 import Web3 from "web3";
+import useValidateCurrentChain from "../../hooks/chain";
 
 const StyledAppealSideBox = styled.div`
   box-shadow: 0px 6px 24px rgba(77, 0, 180, 0.25);
@@ -63,7 +64,8 @@ export default ({
   const amountRemaining = Web3.utils.fromWei(
     (Number(appealFee || 0) - Number(amountContributed || 0)).toString()
   );
-  const onFund = (amount) => {
+  const useOnFund = (amount) => {
+    useValidateCurrentChain(chain);
     governorContractInstance.methods.fundAppeal(submissionIndex).send({
       from: account,
       value: Web3.utils.toWei(amount).toString(),
@@ -112,7 +114,7 @@ export default ({
           "100"
         }
         style={{ marginTop: "25px" }}
-        onSearch={onFund}
+        onSearch={useOnFund}
       />
       <BlueBanner
         heading="For external contributors"

--- a/src/components/info-banner.js
+++ b/src/components/info-banner.js
@@ -26,7 +26,7 @@ const StyledTimeAgo = styled(TimeAgo)`
   line-height: 26px;
 `;
 
-export default ({ governorContractInstance, chain, account, session, snapshotSlug, showTimeout }) => {
+export default ({ governorContractInstance, account, session, snapshotSlug, showTimeout }) => {
   const sessionStart = useFetchSessionStart(governorContractInstance);
   const sessionEnd = useFetchSessionEnd(
     governorContractInstance,

--- a/src/components/info-banner.js
+++ b/src/components/info-banner.js
@@ -5,6 +5,7 @@ import { useFetchSessionStart, useFetchSessionEnd } from "../hooks/governor";
 import { monthIndexToAbbrev } from "../util/text";
 import TimeAgo from "./time-ago";
 import SnapshotLogo from '../assets/logos/snapshot.png'
+import useValidateCurrentChain from "../hooks/chain";
 
 const InfoBanner = styled.div`
   background: #fbf9fe;
@@ -26,7 +27,7 @@ const StyledTimeAgo = styled(TimeAgo)`
   line-height: 26px;
 `;
 
-export default ({ governorContractInstance, account, session, snapshotSlug, showTimeout }) => {
+export default ({ governorContractInstance, chain, account, session, snapshotSlug, showTimeout }) => {
   const sessionStart = useFetchSessionStart(governorContractInstance);
   const sessionEnd = useFetchSessionEnd(
     governorContractInstance,
@@ -62,10 +63,11 @@ export default ({ governorContractInstance, account, session, snapshotSlug, show
                 <Button
                   disabled={!account}
                   type="primary"
-                  onClick={() =>
+                  onClick={() =>{
+                    useValidateCurrentChain(chain);
                     sendExecuteSubmissions.send({
                       from: account,
-                    })
+                    })}
                   }
                 >
                   Execute Submissions

--- a/src/components/info-banner.js
+++ b/src/components/info-banner.js
@@ -26,7 +26,7 @@ const StyledTimeAgo = styled(TimeAgo)`
   line-height: 26px;
 `;
 
-export default ({ governorContractInstance, account, session, snapshotSlug, showTimeout }) => {
+export default ({ governorContractInstance, chain, account, session, snapshotSlug, showTimeout }) => {
   const sessionStart = useFetchSessionStart(governorContractInstance);
   const sessionEnd = useFetchSessionEnd(
     governorContractInstance,

--- a/src/components/list-box/index.js
+++ b/src/components/list-box/index.js
@@ -10,6 +10,7 @@ export default ({
   submittable,
   costPerTx,
   governorContractInstance,
+  chain,
   showByDefault,
   addToPendingLists,
   submittedAt,
@@ -41,6 +42,7 @@ export default ({
         setShowHide={showHideLists}
         withdrawable={isWithdrawable && !submittable && submitter === account}
         governorContractInstance={governorContractInstance}
+        chain={chain}
         account={account}
       />
       {showLists ? (
@@ -49,6 +51,7 @@ export default ({
           submittable={submittable}
           submitter={submitter}
           governorContractInstance={governorContractInstance}
+          chain={chain}
           costPerTx={costPerTx}
           addToPendingLists={addToPendingLists}
           web3={web3}

--- a/src/components/list-box/lists.js
+++ b/src/components/list-box/lists.js
@@ -31,6 +31,7 @@ export default ({
   submittable,
   submitter,
   governorContractInstance,
+  chain,
   costPerTx,
   addToPendingLists,
   web3,
@@ -42,7 +43,8 @@ export default ({
   const tx = txs[selectedTx - 1]
   const [decodedData, setDecodedData] = useState();
   const [_, abi, loading] = useFetchMethodsForContract(
-    tx ? tx.address : ''
+    tx ? tx.address : '',
+    chain
   );
 
   const _onClear = (index) => {
@@ -85,7 +87,7 @@ export default ({
       else {
         if (tx) {
           setDecodedData(
-            <Tooltip title={"ABI must be verified on Etherscan"}>
+            <Tooltip title={"ABI must be verified on the block explorer"}>
               Not available <InfoCircleOutlined />
             </Tooltip>
           );
@@ -141,6 +143,7 @@ export default ({
                 addTx={true}
                 web3={web3}
                 governorContractInstance={governorContractInstance}
+                chain={chain}
                 costPerTx={costPerTx}
               />
             </div>

--- a/src/components/list-box/lists.js
+++ b/src/components/list-box/lists.js
@@ -6,6 +6,7 @@ import { useSubmitPendingList } from "../../hooks/governor";
 import { useFetchMethodsForContract } from "../../hooks/projects";
 import NewTxModal from "../new-list-modal";
 import Web3 from "web3";
+import useValidateCurrentChain from "../../hooks/chain";
 
 const ListsContainer = styled.div`
   background: #ffffff;
@@ -52,7 +53,8 @@ export default ({
     onClear(index)
   }
 
-  const submitEmptyList = () => {
+  const useSubmitEmptyList = () => {
+    useValidateCurrentChain(chain);
     governorContractInstance.methods.submitList([], [], '0x', [], '').send({
       from: submitter,
       value: costPerTx
@@ -127,11 +129,12 @@ export default ({
                     useSubmitPendingList(
                       txs,
                       governorContractInstance,
+                      chain,
                       costPerTx,
                       submitter
                     );
                   else
-                    submitEmptyList()
+                    useSubmitEmptyList()
                 }}
               >
                 <Tooltip title="This deposit will be returned if your list is executed. Deposit can be lost in the event of a dispute.">{`Submit List with ${Web3.utils.fromWei(

--- a/src/components/list-box/top-menu.js
+++ b/src/components/list-box/top-menu.js
@@ -55,6 +55,7 @@ export default ({
   setShowHide,
   withdrawable,
   governorContractInstance,
+  chain,
   account,
 }) => {
   const submissionHash = useFetchSubmissionHash(
@@ -115,7 +116,7 @@ export default ({
           <div style={{ float: "right" }}>
             Submitter
             <Identicon
-              href={`https://etherscan.io/address/${submitter}`}
+              href={chain.scanAddressUrl(submitter)}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/components/list-viewer.js
+++ b/src/components/list-viewer.js
@@ -58,6 +58,7 @@ export default ({
               submitter={sub.submitter}
               web3={web3}
               governorContractInstance={governorContractInstance}
+              chain={chain}
               account={account}
             />
           ))

--- a/src/components/list-viewer.js
+++ b/src/components/list-viewer.js
@@ -12,6 +12,7 @@ const NoListsText = styled.div`
 
 export default ({
   governorContractInstance,
+  chain,
   arbitratorContractInstance,
   pendingLists,
   account,
@@ -32,6 +33,7 @@ export default ({
         showByDefault={true}
         costPerTx={costPerTx}
         governorContractInstance={governorContractInstance}
+        chain={chain}
         addToPendingLists={addToPendingLists}
         web3={web3}
         onClear={onClear}

--- a/src/components/new-list-modal.js
+++ b/src/components/new-list-modal.js
@@ -65,6 +65,7 @@ export default ({
   web3,
   abiCache,
   governorContractInstance,
+  chain,
   costPerTx,
   account
 }) => {
@@ -80,6 +81,7 @@ export default ({
   const [methodInputs, setMethodInputs] = useState([]);
   const [methods, abi] = useFetchMethodsForContract(
     address,
+    chain
   );
 
   const methodToData = () => {

--- a/src/components/project-card.js
+++ b/src/components/project-card.js
@@ -36,7 +36,7 @@ const EtherscanLink = styled.a`
   margin: 10px;
 `;
 
-export default ({ icon, name, address }) => {
+export default ({ icon, name, address, chain }) => {
   return (
     <CardFragment>
       <Link to={`/${name}`}>
@@ -49,7 +49,7 @@ export default ({ icon, name, address }) => {
         <EtherscanLink
           target="_blank"
           rel="noopener noreferrer"
-          href={`https://etherscan.io/address/${address}#code`}
+          href={chain.scanContractUrl(address)}
         >
           <EtherscanLogo />
         </EtherscanLink>

--- a/src/constants/chains.js
+++ b/src/constants/chains.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { ReactComponent as EtherscanLogo } from "../assets/logos/etherscan.svg";
+import { ReactComponent as GnosisLogo } from "../assets/logos/gnosis.svg";
+
+export default {
+  1: {
+    id: '0x1',
+    name: "Mainnet",
+    rpcUrls: ['https://mainnet.infura.io/v3/'],
+    blockExploreUrls: ['https://etherscan.io'],
+    nativeCurrency: {
+      name: 'ETH',
+      symbol: 'ETH', 
+      decimals: 18,
+    },
+    icon: <EtherscanLogo />,
+    scanContractUrl: (contractAddress) =>
+      `https://etherscan.io/address/${contractAddress}#code`,
+    scanAddressUrl: (address) => `https://etherscan.io/address/${address}`,
+    scanAbiUrl: (contractAddress) =>
+      `https://api.etherscan.io/api?module=contract&action=getabi&address=${contractAddress}`,
+  },
+  100: {
+    id: '0x60',
+    name: "Gnosis",
+    rpcUrls: ['https://rpc.gnosischain.com/'],
+    blockExploreUrls: ['https://blockscout.com'],
+    nativeCurrency: {
+      name: 'XDAI',
+      symbol: 'xDai', 
+      decimals: 18,
+    },
+    icon: <GnosisLogo />,
+    scanContractUrl: (contractAddress) =>
+      `https://blockscout.com/xdai/mainnet/address/${contractAddress}/contracts#address-tabs`,
+    scanAddressUrl: (address) =>
+      `https://blockscout.com/xdai/mainnet/address/${address}`,
+    scanAbiUrl: (contractAddress) =>
+      `https://blockscout.com/xdai/mainnet/api?module=contract&action=getabi&address=${contractAddress}`,
+  },
+};

--- a/src/constants/chains.js
+++ b/src/constants/chains.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { ReactComponent as EtherscanLogo } from "../assets/logos/etherscan.svg";
-import { ReactComponent as GnosisLogo } from "../assets/logos/gnosis.svg";
 
 export default {
   1: {
@@ -19,23 +18,5 @@ export default {
     scanAddressUrl: (address) => `https://etherscan.io/address/${address}`,
     scanAbiUrl: (contractAddress) =>
       `https://api.etherscan.io/api?module=contract&action=getabi&address=${contractAddress}`,
-  },
-  100: {
-    id: '0x60',
-    name: "Gnosis",
-    rpcUrls: ['https://rpc.gnosischain.com/'],
-    blockExploreUrls: ['https://blockscout.com'],
-    nativeCurrency: {
-      name: 'XDAI',
-      symbol: 'xDai', 
-      decimals: 18,
-    },
-    icon: <GnosisLogo />,
-    scanContractUrl: (contractAddress) =>
-      `https://blockscout.com/xdai/mainnet/address/${contractAddress}/contracts#address-tabs`,
-    scanAddressUrl: (address) =>
-      `https://blockscout.com/xdai/mainnet/address/${address}`,
-    scanAbiUrl: (contractAddress) =>
-      `https://blockscout.com/xdai/mainnet/api?module=contract&action=getabi&address=${contractAddress}`,
-  },
+  }
 };

--- a/src/constants/projects.js
+++ b/src/constants/projects.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Chains from "./chains";
 import { ReactComponent as KlerosLogo } from "../assets/logos/kleros.svg";
 import { ReactComponent as PohLogo } from "../assets/logos/poh.svg";
 import { ReactComponent as UbiLogo } from "../assets/logos/ubi.svg";
@@ -10,6 +11,7 @@ export default [
     governorAddress: "0xe5bcea6f87aaee4a81f64dfdb4d30d400e0e5cf4",
     arbitratorAddress: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069",
     snapshotSlug: "kleros",
+    chain: Chains[1],
   },
   {
     name: "Proof of Humanity",
@@ -17,6 +19,7 @@ export default [
     governorAddress: "0x327a29fcE0a6490E4236240Be176dAA282EcCfdF",
     arbitratorAddress: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069",
     snapshotSlug: "poh.eth",
+    chain: Chains[1],
   },
   {
     name: "UBI",
@@ -24,5 +27,6 @@ export default [
     governorAddress: "0x7510c77163683448b8Dc8fe9e019d9482Be1ed2b",
     arbitratorAddress: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069",
     snapshotSlug: "ubi-voting.eth",
-  },
+    chain: Chains[1],
+  }
 ];

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -45,6 +45,7 @@ export default (props) => {
               icon={p.icon}
               name={p.name}
               address={p.governorAddress}
+              chain={p.chain}
             />
           </Col>
         ))}

--- a/src/containers/Project.js
+++ b/src/containers/Project.js
@@ -15,7 +15,7 @@ import { useFetchAccount } from "../hooks/account";
 import { useFetchSession, useFetchListSubmissionCost, useFetchSubmittedLists } from "../hooks/governor";
 import { useLocalStorage } from '../hooks/local';
 import { capitalizeString } from "../util/text";
-import { useFetchChainId, askForChainChange } from "../hooks/chain";
+import useValidateCurrentChain from "../hooks/chain";
 
 const Dot = styled.div`
   height: 8px;
@@ -130,6 +130,7 @@ export default (props) => {
 
   // Web3 Objects
   const projectInfo = useFetchProjectByName(params.projectName);
+  useValidateCurrentChain(projectInfo.chain);
   const governorContractInstance = new props.web3.eth.Contract(
     GovernorInterface.abi,
     projectInfo.governorAddress
@@ -152,11 +153,6 @@ export default (props) => {
     props.web3,
     session.currentSessionNumber || "0"
   );
-
-  const chainId = useFetchChainId(props.web3);
-  if (chainId && chainId != projectInfo.chain.id) {
-    askForChainChange(projectInfo.chain);
-  }
 
   return (
     <StyledProjectHome>
@@ -181,6 +177,7 @@ export default (props) => {
         governorContractInstance={governorContractInstance}
         account={account}
         session={session}
+        chain={projectInfo.chain}
         snapshotSlug={projectInfo.snapshotSlug}
         showTimeout={!!submittedLists.length}
       />

--- a/src/containers/Project.js
+++ b/src/containers/Project.js
@@ -179,7 +179,6 @@ export default (props) => {
       </Row>
       <InfoBanner
         governorContractInstance={governorContractInstance}
-        chain={projectInfo.chain}
         account={account}
         session={session}
         snapshotSlug={projectInfo.snapshotSlug}

--- a/src/containers/Project.js
+++ b/src/containers/Project.js
@@ -15,6 +15,7 @@ import { useFetchAccount } from "../hooks/account";
 import { useFetchSession, useFetchListSubmissionCost, useFetchSubmittedLists } from "../hooks/governor";
 import { useLocalStorage } from '../hooks/local';
 import { capitalizeString } from "../util/text";
+import { useFetchChainId, askForChainChange } from "../hooks/chain";
 
 const Dot = styled.div`
   height: 8px;
@@ -152,6 +153,11 @@ export default (props) => {
     session.currentSessionNumber || "0"
   );
 
+  const chainId = useFetchChainId(props.web3);
+  if (chainId && chainId != projectInfo.chain.id) {
+    askForChainChange(projectInfo.chain);
+  }
+
   return (
     <StyledProjectHome>
       <Row>
@@ -160,9 +166,9 @@ export default (props) => {
             <Link to="/">Governor</Link>
             {
               <span style={{ fontWeight: "300" }}>
-                {" "}
+                {" "} 
                 / {projectInfo.icon}
-                {capitalizeString(params.projectName)}
+                {capitalizeString(`${params.projectName} @ ${projectInfo.chain.name}`)}
               </span>
             }
           </StyledHeader>
@@ -173,6 +179,7 @@ export default (props) => {
       </Row>
       <InfoBanner
         governorContractInstance={governorContractInstance}
+        chain={projectInfo.chain}
         account={account}
         session={session}
         snapshotSlug={projectInfo.snapshotSlug}
@@ -258,6 +265,7 @@ export default (props) => {
       )}
       <ListViewer
         governorContractInstance={governorContractInstance}
+        chain={projectInfo.chain}
         arbitratorContractInstance={arbitratorContractInstance}
         account={account}
         pendingLists={pendingLists}
@@ -272,6 +280,7 @@ export default (props) => {
         <AppealModule
           session={session}
           governorContractInstance={governorContractInstance}
+          chain={projectInfo.chain}
           arbitratorContractInstance={arbitratorContractInstance}
           web3={props.web3}
           account={account}

--- a/src/hooks/chain.js
+++ b/src/hooks/chain.js
@@ -1,21 +1,6 @@
-import { useState, useEffect } from "react";
-
 const MISSING_CHAIN_ERROR_CODE = 4902;
 
-export const useFetchChainId = (web3) => {
-  const [chainId, setChainId] = useState();
-
-  useEffect(() => {
-    web3.eth.getChainId().then((chainId) => {
-      const chainIdAsHexa = `0x${chainId.toString(16)}`; 
-      setChainId(chainIdAsHexa)
-    });
-  }, []);
-
-  return chainId;
-};
-
-export const askForChainChange = async (chain) => {
+const useValidateCurrentChain = async (chain) => {
   if (window.ethereum) {
     try {
       await window.ethereum.request({
@@ -47,3 +32,5 @@ export const askForChainChange = async (chain) => {
     alert('MetaMask is not installed. Please consider installing it: https://metamask.io/download.html');
   } 
 }
+
+export default useValidateCurrentChain;

--- a/src/hooks/chain.js
+++ b/src/hooks/chain.js
@@ -1,0 +1,49 @@
+import { useState, useEffect } from "react";
+
+const MISSING_CHAIN_ERROR_CODE = 4902;
+
+export const useFetchChainId = (web3) => {
+  const [chainId, setChainId] = useState();
+
+  useEffect(() => {
+    web3.eth.getChainId().then((chainId) => {
+      const chainIdAsHexa = `0x${chainId.toString(16)}`; 
+      setChainId(chainIdAsHexa)
+    });
+  }, []);
+
+  return chainId;
+};
+
+export const askForChainChange = async (chain) => {
+  if (window.ethereum) {
+    try {
+      await window.ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: chain.id }], 
+      });
+    } catch (error) {
+      if (MISSING_CHAIN_ERROR_CODE === error.code) {
+        try {
+          await window.ethereum.request({
+            method: 'wallet_addEthereumChain',
+            params: [
+              {
+                chainId: chain.id,
+                chainName: chain.name,
+                rpcUrls: chain.rpcUrls,
+                blockExplorerUrls: chain.blockExplorerUrls,
+                nativeCurrency: chain.nativeCurrency
+              },
+            ],
+          });
+        } catch (addError) {
+          console.error(`addEthereumChain failes with: ${JSON.stringify(addError)}`);
+        }
+      }
+      console.error(`wallet_switchEthereumChain failes with: ${JSON.stringify(error)}`);
+    }
+  } else {
+    alert('MetaMask is not installed. Please consider installing it: https://metamask.io/download.html');
+  } 
+}

--- a/src/hooks/governor.js
+++ b/src/hooks/governor.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import Web3 from "web3";
 import { orderParametersByHash } from "../util/tx-hash";
+import useValidateCurrentChain from "./chain";
 
 /**
  Fetch the time of the start of the session.
@@ -227,6 +228,7 @@ export const useFetchListSubmissionCost = (
 export const useSubmitPendingList = (
   txs,
   governorContractInstance,
+  chain,
   costPerTx,
   account
 ) => {
@@ -234,7 +236,7 @@ export const useSubmitPendingList = (
     txs
   );
 
-  console.log(`calling submit list hehe ${window.ethereum}`);
+  useValidateCurrentChain(chain);
   governorContractInstance.methods
     .submitList(addresses, values, data, dataSizes, titles)
     .send({

--- a/src/hooks/governor.js
+++ b/src/hooks/governor.js
@@ -234,6 +234,7 @@ export const useSubmitPendingList = (
     txs
   );
 
+  console.log(`calling submit list hehe ${window.ethereum}`);
   governorContractInstance.methods
     .submitList(addresses, values, data, dataSizes, titles)
     .send({

--- a/src/hooks/projects.js
+++ b/src/hooks/projects.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import Projects from "../constants/projects";
-import { useLocalStorage } from './local'
+import { useLocalStorage } from "./local";
 
 export const useFetchAllProjects = () => {
   const [allProjects, setAllProjects] = useState([]);
@@ -20,7 +20,8 @@ export const useFetchProjectByName = (name) => {
 };
 
 export const useFetchMethodsForContract = (
-  contractAddress
+  contractAddress,
+  network
 ) => {
   const [ abiCache, setAbiCache ] = useLocalStorage('ABIS', {})
 
@@ -35,10 +36,10 @@ export const useFetchMethodsForContract = (
     const _fetchABI = async () => {
       let _abi = abiCache[contractAddress];
 
-      // Fetch from etherscan
+      // Fetch from chain block explorer
       if (!_abi) {
         const abiQuery = await fetch(
-          `https://api.etherscan.io/api?module=contract&action=getabi&address=${contractAddress}`
+          network.scanAbiUrl(contractAddress)
         ).then((response) => response.json());
         if (abiQuery.status === "1") {
           _abi = JSON.parse(abiQuery.result);


### PR DESCRIPTION
## Relevant changes

- Chain data (block explorer urls, for example) was parameterized under [src/constants/chains.js](https://github.com/kleros/governor-snapshot/pull/9/files#diff-6795bd96931b077a27043fdfaabbc28af7fd348f5d57ff79fa5b6fc90ccdd73e) with similar structure as [src/constants/projects.js] (https://github.com/kleros/governor-snapshot/blob/2fab91d7e23ce7a1fb9a650170270006fa1797fd/src/constants/projects.js) 
- Added `chain` attribute in each project.
- Usage of the new chain attribute to [validateCurrentChain](https://github.com/kleros/governor-snapshot/pull/9/files#diff-97035f65664100547975eb265de8b0b19b32013a17ed1b7ed083557bf89a4c95) when: 
  - you navigate to a project.
  - you attempt to call a contract write-method.

In the title you can also see the information of the project chain
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/12705929/201441345-1d17398d-b0ef-4a67-a3c0-112797be75fb.png">


https://user-images.githubusercontent.com/12705929/201440913-e8270cf0-4c97-4223-9b83-b174581f8bb4.mov


https://user-images.githubusercontent.com/12705929/201821359-e56cf578-2409-46b1-aed9-29218fb202d8.mov



With this, a new chain governor can be configured easy just adding the project information in `src/constants/projects.js` and adding the chain configuration in `src/constants/chains.js`.

This is the first in order to solve [Gnosis Fork Dao Governor issue](https://github.com/kleros/governor-snapshot/issues/5)
